### PR TITLE
more release bits

### DIFF
--- a/.github/workflows/daemonizer.yml
+++ b/.github/workflows/daemonizer.yml
@@ -8,22 +8,45 @@ on:
       - master
 
 jobs:
+  get_version:
+    name: Get version info
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      version: ${{ steps.spec_ver.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get package version
+        id: spec_ver
+        run: |
+          version=$(make version)
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo Version from spec: $version
+        env:
+          NAME: python-daemonizer
+
   build_rpms:
     name: daemonizer-rpms
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        name: [centos9, rocky9]
+        name: [rocky9]
         include:
-          - name: centos9
-            spec: python-daemonizer
-            image: quay.io/centos/centos:stream9
           - name: rocky9
             spec: python-daemonizer
             image: quay.io/rockylinux/rockylinux:9
 
     runs-on: ubuntu-latest
+    needs: [get_version]
     container:
       image: ${{ matrix.image }}
     permissions:
@@ -44,18 +67,15 @@ jobs:
       if: matrix.image
       run: chown root.root .
 
+    - name: Check version and update spec
+      env:
+        VERSION: ${{ needs.get_version.outputs.version }}
+      run: |
+        echo Dev version from get_version step: $VERSION
+
     - name: Install deps for rpm builds (centos/rocky)
       run: |
         bash scripts/install_deps_el9.sh
-
-    - name: Get package version
-      id: spec_ver
-      run: |
-        version=$(make version)
-        echo "VERSION=${version}" >> $GITHUB_ENV
-        echo Version from spec: $version
-      env:
-        NAME: ${{ matrix.spec }}
 
     - name: Build bdist_rpm pkgs
       run: |
@@ -64,7 +84,56 @@ jobs:
     - name: Upload rpm files
       uses: actions/upload-artifact@v4
       with:
-        name: "${{ matrix.spec }}-${{ env.VERSION }}.${{ matrix.name }}-rpms"
+        name: packages
         path: |
           tmp/RPMS/*/*.rpm
           tmp/SRPMS/*.rpm
+
+  create-release:
+    name: Create daemonizer Release
+    runs-on: ubuntu-latest
+    needs: [get_version, build_rpms]
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download Artifacts
+      uses: actions/download-artifact@v4
+
+    - name: List Artifacts
+      run: ls -laR packages
+
+    - name: Fetch tags
+      run: git fetch --tags --prune --quiet
+
+    - name: Tag Release
+      id: tag_release
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        set +e
+        if git rev-list "daemonizer-${{ needs.get_version.outputs.version }}" >/dev/null 2>&1 ; then
+          echo "Tag for daemonizer-${{ needs.get_version.outputs.version }} already exists. Skipping release creation."
+          echo "NEW_RELEASE=false" >> $GITHUB_OUTPUT
+        else
+          git tag "daemonizer-${{ needs.get_version.outputs.version }}"
+          git push origin "daemonizer-${{ needs.get_version.outputs.version }}"
+          echo "NEW_RELEASE=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create draft release
+      id: create_release
+      if: ${{ github.event_name != 'pull_request' && steps.tag_release.outputs.NEW_RELEASE == 'true' }}
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: daemonizer-${{ needs.get_version.outputs.version }}
+        name: Release daemonizer-${{ needs.get_version.outputs.version }}
+        body: Latest RPMs for daemonizer-${{ needs.get_version.outputs.version }}
+        draft: false
+        prerelease: false
+        files: |
+          packages/RPMS/*/*.rpm
+          packages/SRPMS/*.rpm

--- a/.github/workflows/diskcache.yml
+++ b/.github/workflows/diskcache.yml
@@ -8,22 +8,45 @@ on:
       - master
 
 jobs:
+  get_version:
+    name: Get version info
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      version: ${{ steps.spec_ver.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get package version
+        id: spec_ver
+        run: |
+          version=$(make version)
+          echo "version=${version}" >> $GITHUB_OUTPUT
+          echo Version from spec: $version
+        env:
+          NAME: python-diskcache
+
   build_rpms:
     name: diskcache-rpms
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        name: [centos9, rocky9]
+        name: [rocky9]
         include:
-          - name: centos9
-            spec: python-diskcache
-            image: quay.io/centos/centos:stream9
           - name: rocky9
             spec: python-diskcache
             image: quay.io/rockylinux/rockylinux:9
 
     runs-on: ubuntu-latest
+    needs: [get_version]
     container:
       image: ${{ matrix.image }}
     permissions:
@@ -44,18 +67,15 @@ jobs:
       if: matrix.image
       run: chown root.root .
 
+    - name: Check version and update spec
+      env:
+        VERSION: ${{ needs.get_version.outputs.version }}
+      run: |
+        echo Dev version from get_version step: $VERSION
+
     - name: Install deps for rpm builds (centos/rocky)
       run: |
         bash scripts/install_deps_el9.sh
-
-    - name: Get package version
-      id: spec_ver
-      run: |
-        version=$(make version)
-        echo "VERSION=${version}" >> $GITHUB_ENV
-        echo Version from spec: $version
-      env:
-        NAME: ${{ matrix.spec }}
 
     - name: Build bdist_rpm pkgs
       run: |
@@ -64,7 +84,56 @@ jobs:
     - name: Upload rpm files
       uses: actions/upload-artifact@v4
       with:
-        name: "${{ matrix.spec }}-${{ env.VERSION }}.${{ matrix.name }}-rpms"
+        name: packages
         path: |
           tmp/RPMS/*/*.rpm
           tmp/SRPMS/*.rpm
+
+  create-release:
+    name: Create diskcache Release
+    runs-on: ubuntu-latest
+    needs: [get_version, build_rpms]
+    permissions:
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download Artifacts
+      uses: actions/download-artifact@v4
+
+    - name: List Artifacts
+      run: ls -laR packages
+
+    - name: Fetch tags
+      run: git fetch --tags --prune --quiet
+
+    - name: Tag Release
+      id: tag_release
+      if: ${{ github.event_name != 'pull_request' }}
+      run: |
+        set +e
+        if git rev-list "diskcache-${{ needs.get_version.outputs.version }}" >/dev/null 2>&1 ; then
+          echo "Tag for diskcache-${{ needs.get_version.outputs.version }} already exists. Skipping release creation."
+          echo "NEW_RELEASE=false" >> $GITHUB_OUTPUT
+        else
+          git tag "diskcache-${{ needs.get_version.outputs.version }}"
+          git push origin "diskcache-${{ needs.get_version.outputs.version }}"
+          echo "NEW_RELEASE=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Create draft release
+      id: create_release
+      if: ${{ github.event_name != 'pull_request' && steps.tag_release.outputs.NEW_RELEASE == 'true' }}
+      uses: softprops/action-gh-release@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: diskcache-${{ needs.get_version.outputs.version }}
+        name: Release diskcache-${{ needs.get_version.outputs.version }}
+        body: Latest RPMs for diskcache-${{ needs.get_version.outputs.version }}
+        draft: false
+        prerelease: false
+        files: |
+          packages/RPMS/*/*.rpm
+          packages/SRPMS/*.rpm


### PR DESCRIPTION
* all release jobs should trigger only when GH event is not a pull_request and the given name-version tag string does not exist
* ie, each workflow should create the new release when the PR is merged to master and the version/release has changed